### PR TITLE
Enhance feature/game_pause_dialog

### DIFF
--- a/lib/src/ui/common/common_game_pause_dialog_view.dart
+++ b/lib/src/ui/common/common_game_pause_dialog_view.dart
@@ -42,7 +42,7 @@ class CommonGamePauseDialogView extends StatelessWidget {
               child: InkWell(
                 borderRadius: BorderRadius.all(Radius.circular(16)),
                 onTap: () {
-                  Navigator.pop(context);
+                  Navigator.pop(context, true);
                 },
                 child: SizedBox(
                   height: 38,


### PR DESCRIPTION
This pull request addresses the issue related to the behavior of the close icon in the CommonGamePauseDialogView component. Currently, when the gamer clicks on the close icon, the game simply finishes without any further action. The proposed solution is to modify the existing code from Navigator.pop(context); to Navigator.pop(context, true);.

The updated code will enhance the user experience by allowing them to exit the game seamlessly when desired. The pull request aims to improve the functionality of the CommonGamePauseDialogView component and enhance its behavior in response to the close icon interaction.
